### PR TITLE
Add internal version of munmap that makes the SYS_munmap syscall.

### DIFF
--- a/include/libunwind_i.h
+++ b/include/libunwind_i.h
@@ -56,6 +56,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #include <string.h>
 #include <unistd.h>
 #include <sys/mman.h>
+#include <sys/syscall.h>   /* For SYS_xxx definitions */
 
 #if defined(HAVE_ELF_H)
 # include <elf.h>
@@ -353,5 +354,12 @@ static inline void invalidate_edi (struct elf_dyn_info *edi)
 #endif
 
 #define UNW_ALIGN(x,a) (((x)+(a)-1UL)&~((a)-1UL))
+
+/* Provide an internal syscall version of munmap to improve signal safety. */
+static ALWAYS_INLINE int
+mi_munmap (void *addr, size_t len)
+{
+  return syscall (SYS_munmap, addr, len);
+}
 
 #endif /* libunwind_i_h */

--- a/src/dwarf/Gfind_proc_info-lsb.c
+++ b/src/dwarf/Gfind_proc_info-lsb.c
@@ -108,7 +108,7 @@ load_debug_frame (const char *file, char **buf, size_t *bufsize, int is_local)
   if (!shdr ||
       (shdr->sh_offset + shdr->sh_size > ei.size))
     {
-      munmap(ei.image, ei.size);
+      mi_munmap(ei.image, ei.size);
       return 1;
     }
 
@@ -120,7 +120,7 @@ load_debug_frame (const char *file, char **buf, size_t *bufsize, int is_local)
   Debug (4, "read %zd bytes of .debug_frame from offset %zd\n",
 	 *bufsize, shdr->sh_offset);
 
-  munmap(ei.image, ei.size);
+  mi_munmap(ei.image, ei.size);
   return 0;
 }
 
@@ -448,7 +448,7 @@ dwarf_find_eh_frame_section(struct dl_phdr_info *info)
          eh_frame);
 
 out:
-  munmap (ei.image, ei.size);
+  mi_munmap (ei.image, ei.size);
 
   return eh_frame;
 }

--- a/src/dwarf/Gparser.c
+++ b/src/dwarf/Gparser.c
@@ -527,9 +527,9 @@ dwarf_flush_rs_cache (struct dwarf_rs_cache *cache)
     cache->log_size = DWARF_DEFAULT_LOG_UNW_CACHE_SIZE;
   } else {
     if (cache->hash && cache->hash != cache->default_hash)
-      munmap(cache->hash, DWARF_UNW_HASH_SIZE(cache->prev_log_size));
+      mi_munmap(cache->hash, DWARF_UNW_HASH_SIZE(cache->prev_log_size));
     if (cache->buckets && cache->buckets != cache->default_buckets)
-      munmap(cache->buckets, DWARF_UNW_CACHE_SIZE(cache->prev_log_size));
+      mi_munmap(cache->buckets, DWARF_UNW_CACHE_SIZE(cache->prev_log_size));
     GET_MEMORY(cache->hash, DWARF_UNW_HASH_SIZE(cache->log_size)
                              * sizeof (cache->hash[0]));
     GET_MEMORY(cache->buckets, DWARF_UNW_CACHE_SIZE(cache->log_size)

--- a/src/elfxx.c
+++ b/src/elfxx.c
@@ -248,7 +248,7 @@ elf_w (extract_minidebuginfo) (struct elf_image *ei, struct elf_image *mdi)
   if (lret != LZMA_OK)
     {
       Debug (1, "LZMA decompression failed: %d\n", lret);
-      munmap (mdi->image, mdi->size);
+      mi_munmap (mdi->image, mdi->size);
       return 0;
     }
 
@@ -295,7 +295,7 @@ elf_w (get_proc_name_in_image) (unw_addr_space_t as, struct elf_image *ei,
           ret = ret_mdi;
         }
 
-      munmap (mdi.image, mdi.size);
+      mi_munmap (mdi.image, mdi.size);
     }
 
   if (min_dist >= ei->size)
@@ -324,7 +324,7 @@ elf_w (get_proc_name) (unw_addr_space_t as, pid_t pid, unw_word_t ip,
 
   ret = elf_w (get_proc_name_in_image) (as, &ei, segbase, mapoff, ip, buf, buf_len, offp);
 
-  munmap (ei.image, ei.size);
+  mi_munmap (ei.image, ei.size);
   ei.image = NULL;
 
   return ret;
@@ -420,7 +420,7 @@ elf_w (load_debuglink) (const char* file, struct elf_image *ei, int is_local)
       if (memchr (linkbuf, 0, shdr->sh_size) == NULL)
 	return 0;
 
-      munmap (ei->image, ei->size);
+      mi_munmap (ei->image, ei->size);
       ei->image = NULL;
 
       Debug(1, "Found debuglink section, following %s\n", linkbuf);

--- a/src/elfxx.h
+++ b/src/elfxx.h
@@ -32,6 +32,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
 #include "libunwind_i.h"
 
+static int mi_munmap (void *addr, size_t len);
+
 #if ELF_CLASS == ELFCLASS32
 # define ELF_W(x)       ELF32_##x
 # define Elf_W(x)       Elf32_##x
@@ -93,7 +95,7 @@ elf_map_image (struct elf_image *ei, const char *path)
 
   if (!elf_w (valid_object) (ei))
   {
-    munmap(ei->image, ei->size);
+    mi_munmap(ei->image, ei->size);
     return -1;
   }
 

--- a/src/os-linux.h
+++ b/src/os-linux.h
@@ -289,7 +289,7 @@ maps_close (struct map_iterator *mi)
   mi->fd = -1;
   if (mi->buf)
     {
-      munmap (mi->buf_end - mi->buf_size, mi->buf_size);
+      mi_munmap (mi->buf_end - mi->buf_size, mi->buf_size);
       mi->buf = mi->buf_end = NULL;
     }
 }

--- a/src/x86_64/Gtrace.c
+++ b/src/x86_64/Gtrace.c
@@ -68,7 +68,7 @@ trace_cache_free (void *arg)
   }
   tls_cache_destroyed = 1;
   tls_cache = NULL;
-  munmap (cache->frames, (1u << cache->log_size) * sizeof(unw_tdep_frame_t));
+  mi_munmap (cache->frames, (1u << cache->log_size) * sizeof(unw_tdep_frame_t));
   mempool_free (&trace_cache_pool, cache);
   Debug(5, "freed cache %p\n", cache);
 }
@@ -150,7 +150,7 @@ trace_cache_expand (unw_trace_cache_t *cache)
   }
 
   Debug(5, "expanded cache from 2^%lu to 2^%lu buckets\n", cache->log_size, new_log_size);
-  munmap(cache->frames, old_size * sizeof(unw_tdep_frame_t));
+  mi_munmap(cache->frames, old_size * sizeof(unw_tdep_frame_t));
   cache->frames = new_frames;
   cache->log_size = new_log_size;
   cache->used = 0;


### PR DESCRIPTION
This improves the signal safety, because munmap is a weak symbol
that can be overwritten by a library which can lead to deadlocks.
(see OpenMPI)